### PR TITLE
[ADD] Config params and asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,11 @@ Starting with version 1, the changelog is kept inside the Releases tab in our th
 ### Modify
 - Modify params of files make repository and make service
 - Maker for CRUD files: make:crudsrv, make:repository --interface, make:repository, make:service --interface and make:service
+
+## 1.0.3 - 2022-01-09
+
+### Modify
+- Modify params of files make repository and make service
+- For create only interface class use : make:repository --interface, make:repository, make:service --interface and make:service
+- For set your folder of services and repositories publish the config file: php artisan vendor:publish --tag=makeservicerepository-config
+- Allows configuring whether the contracts will be in the same entity's folder through the config file in the parameter create_contract_in_same_folder_entity by default it is true

--- a/README.md
+++ b/README.md
@@ -21,25 +21,25 @@ php artisan make:crudsrv {Entity_name}
 
 ```
 
-- Generate a Repository Interface
+- Generate only Repository Interface class
 
 ``` bash
-php artisan make:repository --interface {Entity_name}
+php artisan make:repository {Entity_name} --interface 
 ```
 
-- Generate a Service Interface
+- Generate only Service Interface class
 
 ``` bash
-php artisan make:service --interface {Entity_name}
+php artisan make:service {Entity_name} --interface
 ```
 
-- Generate a Service
+- Generate a Service, You will be asked if you want to create the interface too
 
 ``` bash
 php artisan make:service {Entity_name}
 ``` 
 
-- Generate a Repository file
+- Generate a Repository, You will be asked if you want to create the interface too
 
 ``` bash
 php artisan make:repository {Entity_name}

--- a/config/makeservicerepository/base.php
+++ b/config/makeservicerepository/base.php
@@ -2,6 +2,13 @@
 
 return [
 
-   // TODO: Implements
+    'create_contract_in_same_folder_entity' => true,
 
+    // Set your directory of service contract and service pattern
+    'service_contract_pattern_directory' => 'App\Contracts\Services',
+    'service_pattern_directory' => 'App\Services',
+
+    // Set your directory of repository contract and repository pattern
+    'repository_contract_pattern_directory' => 'App\Contracts\Repositories',
+    'repository_pattern_directory' => 'App\Repositories',
 ];

--- a/src/Console/Commands/MakeRepository.php
+++ b/src/Console/Commands/MakeRepository.php
@@ -2,134 +2,50 @@
 
 namespace FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands;
 
-use Illuminate\Console\GeneratorCommand;
+use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Illuminate\Support\Str;
 
-class MakeRepository extends GeneratorCommand
+class MakeRepository extends Command
 {
 	/**
 	 * The name and signature of the console command.
 	 *
 	 * @var string
 	 */
-	protected $name = 'make:repository {--interface}';
+    protected $signature = 'make:repository {name} {--interface}';
 
-    private $complementaryInterfaceName = 'RepositoryInterface';
-    private $complementaryRepositoryName = 'Repository';
 
 	/**
 	 * The console command description.
 	 *
 	 * @var string
 	 */
-	protected $description = 'Create a new repository';
+	protected $description = 'Create a new repository pattern';
 
 	/**
 	 * The type of class being generated.
 	 *
 	 * @var string
 	 */
-	protected $type = 'Repository';
+	protected $type = 'repository';
 
-    /**
-     * Replace the class name for the given stub.
-     *
-     * @param  string  $stub
-     * @param  string  $name
-     * @return string
-     */
-    protected function replaceClass($stub, $name)
+    public function handle()
     {
+        $name = (string) $this->argument('name');
+        $nameTitle = ucfirst(Str::camel($name));
 
-        $stub = parent::replaceClass($stub, $name);
+        if (!$this->option('interface')) {
+            if ($this->confirm('Create Repository Interface ? ', true)){
+                $this->call('make:repositoryPattern', ['name' => $nameTitle, '--interface'=> true]);
+            }
 
-        if($this->option('interface'))
-        {
-            return $this->replaceClassInterface($stub);
+            $this->call('make:repositoryPattern', ['name' => $nameTitle]);
+
+            return;
         }
 
-        return $this->replaceClasses($stub);
-    }
+        $this->call('make:repositoryPattern', ['name' => $nameTitle, '--interface'=> true]);
 
-    private function replaceClassInterface($stub)
-    {
-        return str_replace('DummyRepositoryContract', $this->argument('name').$this->complementaryInterfaceName, $stub);
-    }
-
-    private function replaceClasses ($stub){
-
-        $stub = str_replace('DummyRepositoryInterface', $this->argument('name').$this->complementaryInterfaceName, $stub);
-        $stub = str_replace('DummyModel', $this->argument('name'), $stub);
-
-        return str_replace('DummyRepository', $this->argument('name').$this->complementaryRepositoryName, $stub);
-    }
-
-     /**
-     * Get the destination class path.
-     *
-     * @param  string  $name
-     * @return string
-     */
-    protected function getPath($name)
-    {
-        $complementName = ($this->option('interface')) ? $name.$this->complementaryInterfaceName : $name.$this->complementaryRepositoryName;
-        $name = Str::replaceFirst($this->rootNamespace(), '', $complementName);
-
-        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
-    }
-
-	/**
-	 * Get the stub file for the generator.
-	 *
-	 * @return string
-	 */
-	protected function getStub()
-	{
-        if($this->option('interface'))
-        {
-            $this->type = $this->complementaryInterfaceName;
-            return  __DIR__ . '/../stubs/make-repository-interface.stub';
-        }
-
-        $this->type = $this->complementaryRepositoryName;
-        return  __DIR__ . '/../stubs/make-repository.stub';
-	}
-
-	/**
-	 * Get the default namespace for the class.
-	 *
-	 * @param  string  $rootNamespace
-	 * @return string
-	 */
-	protected function getDefaultNamespace($rootNamespace)
-	{
-        if($this->option('interface'))
-        {
-		    return $rootNamespace . '\Contracts\Repositories';
-        }
-
-        return $rootNamespace . '\Repositories';
-	}
-
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-            ['name', InputArgument::REQUIRED, 'The name of the repository.'],
-        ];
-    }
-
-    protected function getOptions()
-    {
-        return [
-            ['force', null, InputOption::VALUE_NONE, 'Create the class even if it already exists'],
-            ['interface', null, InputOption::VALUE_NONE, 'Create the interface class for repository']
-        ];
     }
 }

--- a/src/Console/Commands/MakeRepositoryPattern.php
+++ b/src/Console/Commands/MakeRepositoryPattern.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Illuminate\Support\Str;
+
+class MakeRepositoryPattern extends GeneratorCommand
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:repositoryPattern {--interface}';
+
+    private $complementaryInterfaceName = 'RepositoryInterface';
+    private $complementaryRepositoryName = 'Repository';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Create a new repository';
+
+	/**
+	 * The type of class being generated.
+	 *
+	 * @var string
+	 */
+	protected $type = 'Repository';
+
+    /**
+     * Replace the class name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return string
+     */
+    protected function replaceClass($stub, $name)
+    {
+
+        $stub = parent::replaceClass($stub, $name);
+
+        if($this->option('interface'))
+        {
+            return $this->replaceClassInterface($stub);
+        }
+
+        return $this->replaceClasses($stub);
+    }
+
+    private function replaceClassInterface($stub)
+    {
+        return str_replace('DummyRepositoryContract', $this->argument('name').$this->complementaryInterfaceName, $stub);
+    }
+
+    private function replaceClasses ($stub){
+
+        $stub = str_replace('DummyRepositoryInterfaceNamespace', $this->getRepositoryInterfaceNamespace() , $stub);
+        $stub = str_replace('DummyRepositoryInterface', $this->argument('name').$this->complementaryInterfaceName, $stub);
+        $stub = str_replace('DummyModel', $this->argument('name'), $stub);
+
+        return str_replace('DummyRepository', $this->argument('name').$this->complementaryRepositoryName, $stub);
+    }
+
+    private function getRepositoryInterfaceNamespace()
+    {
+        if (config('makeservicerepository.base.create_contract_in_same_folder_entity')) {
+            return config('makeservicerepository.base.repository_pattern_directory') .'\\'. $this->argument('name');
+        }
+
+        return config('makeservicerepository.base.repository_contract_pattern_directory');
+    }
+
+     /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $complementName = ($this->option('interface')) ? $name.$this->complementaryInterfaceName : $name.$this->complementaryRepositoryName;
+        $name = Str::replaceFirst($this->rootNamespace(), '', $complementName);
+
+        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+    }
+
+	/**
+	 * Get the stub file for the generator.
+	 *
+	 * @return string
+	 */
+	protected function getStub()
+	{
+        if($this->option('interface'))
+        {
+            $this->type = $this->complementaryInterfaceName;
+            return  __DIR__ . '/../stubs/make-repository-interface.stub';
+        }
+
+        $this->type = $this->complementaryRepositoryName;
+        return  __DIR__ . '/../stubs/make-repository.stub';
+	}
+
+	/**
+	 * Get the default namespace for the class.
+	 *
+	 * @param  string  $rootNamespace
+	 * @return string
+	 */
+	protected function getDefaultNamespace($rootNamespace)
+	{
+        if($this->option('interface'))
+        {
+           return $this->getRepositoryInterfaceNamespace();
+        }
+
+        return $this->getRepositoryNamespace();
+	}
+
+    private function getRepositoryNamespace()
+    {
+        if (config('makeservicerepository.base.create_contract_in_same_folder_entity')) {
+            return config('makeservicerepository.base.repository_pattern_directory') .'\\'. $this->argument('name');
+        }
+
+		return config('makeservicerepository.base.repository_pattern_directory');
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the repository.'],
+        ];
+    }
+
+    protected function getOptions()
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Create the class even if it already exists'],
+            ['interface', null, InputOption::VALUE_NONE, 'Create the interface class for repository']
+        ];
+    }
+}

--- a/src/Console/Commands/MakeService.php
+++ b/src/Console/Commands/MakeService.php
@@ -2,122 +2,51 @@
 
 namespace FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands;
 
-use Illuminate\Support\Str;
-use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Input\InputOption;
+use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Support\Str;
 
-
-class MakeService extends GeneratorCommand
+class MakeService extends Command
 {
 	/**
 	 * The name and signature of the console command.
 	 *
 	 * @var string
 	 */
-	protected $name = 'make:service';
+    protected $signature = 'make:service {name} {--interface}';
 
-    private $complementaryInterfaceName = 'ServiceInterface';
-    private $complementaryRepositoryInterfaceName = 'RepositoryInterface';
-    private $complementaryServiceName = 'Service';
 
 	/**
 	 * The console command description.
 	 *
 	 * @var string
 	 */
-	protected $description = 'Create a new contract interface';
+	protected $description = 'Create a new service pattern';
 
 	/**
 	 * The type of class being generated.
 	 *
 	 * @var string
 	 */
-	protected $type = 'Service';
+	protected $type = 'service';
 
-    /**
-     * Replace the class name for the given stub.
-     *
-     * @param  string  $stub
-     * @param  string  $name
-     * @return string
-     */
-    protected function replaceClass($stub, $name)
+    public function handle()
     {
+        $name = (string) $this->argument('name');
+        $nameTitle = ucfirst(Str::camel($name));
 
-        $stub = parent::replaceClass($stub, $name);
+        if (!$this->option('interface')) {
+             // Create a service interface and repository
+            if ($this->confirm('Create Service Interface ? ', true)){
+                $this->call('make:servicePattern', ['name' => $nameTitle, '--interface'=> true]);
+            }
 
-        $stub = str_replace('DummyRepositoryInterface', $this->argument('name').$this->complementaryRepositoryInterfaceName, $stub);
-        $stub = str_replace('DummyServiceInterface', $this->argument('name').$this->complementaryInterfaceName, $stub);
-        $stub = str_replace('DummyContract', $this->argument('name').$this->complementaryInterfaceName, $stub);
+            $this->call('make:servicePattern', ['name' => $nameTitle]);
 
-        return str_replace('DummyService', $this->argument('name').$this->complementaryServiceName, $stub);
-    }
-
-     /**
-     * Get the destination class path.
-     *
-     * @param  string  $name
-     * @return string
-     */
-    protected function getPath($name)
-    {
-        $complementName = ($this->option('interface')) ? $name.$this->complementaryInterfaceName : $name.$this->complementaryServiceName;
-        $name = Str::replaceFirst($this->rootNamespace(), '', $complementName);
-
-        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
-    }
-
-	/**
-	 * Get the stub file for the generator.
-	 *
-	 * @return string
-	 */
-	protected function getStub()
-	{
-        if($this->option('interface'))
-        {
-            $this->type = $this->complementaryInterfaceName;
-		    return  __DIR__ . '/../stubs/make-service-interface.stub';
+            return;
         }
 
-        $this->type = $this->complementaryServiceName;
-        return  __DIR__ . '/../stubs/make-service.stub';
-	}
+        $this->call('make:servicePattern', ['name' => $nameTitle, '--interface'=> true]);
 
-	/**
-	 * Get the default namespace for the class.
-	 *
-	 * @param  string  $rootNamespace
-	 * @return string
-	 */
-	protected function getDefaultNamespace($rootNamespace)
-	{
-        if($this->option('interface'))
-        {
-            return $rootNamespace . '\Contracts\Services';
-        }
-
-		return $rootNamespace . '\Services';
-	}
-
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-            ['name', InputArgument::REQUIRED, 'The name of the contract.'],
-        ];
-    }
-
-    protected function getOptions()
-    {
-        return [
-            ['force', null, InputOption::VALUE_NONE, 'Create the class even if it already exists'],
-            ['interface', null, InputOption::VALUE_NONE, 'Create the interface class for repository']
-        ];
     }
 }

--- a/src/Console/Commands/MakeServicePattern.php
+++ b/src/Console/Commands/MakeServicePattern.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+
+class MakeServicePattern extends GeneratorCommand
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:servicePattern {--interface}';
+
+    private $complementaryInterfaceName = 'ServiceInterface';
+    private $complementaryRepositoryInterfaceName = 'RepositoryInterface';
+    private $complementaryServiceName = 'Service';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Create a new contract interface';
+
+	/**
+	 * The type of class being generated.
+	 *
+	 * @var string
+	 */
+	protected $type = 'Service';
+
+    /**
+     * Replace the class name for the given stub.
+     *
+     * @param  string  $stub
+     * @param  string  $name
+     * @return string
+     */
+    protected function replaceClass($stub, $name)
+    {
+
+        $stub = parent::replaceClass($stub, $name);
+
+        $stub = str_replace('DummyRepositoryInterfacePath', $this->getRepositoryInterfaceNameSpace() , $stub);
+        $stub = str_replace('DummyServiceInterfacePath', $this->getServiceInterfaceNameSpace() , $stub);
+        $stub = str_replace('DummyRepositoryInterface', $this->argument('name').$this->complementaryRepositoryInterfaceName, $stub);
+        $stub = str_replace('DummyServiceInterface', $this->argument('name').$this->complementaryInterfaceName, $stub);
+        $stub = str_replace('DummyContract', $this->argument('name').$this->complementaryInterfaceName, $stub);
+
+        return str_replace('DummyService', $this->argument('name').$this->complementaryServiceName, $stub);
+    }
+
+     /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $complementName = ($this->option('interface')) ? $name.$this->complementaryInterfaceName : $name.$this->complementaryServiceName;
+        $name = Str::replaceFirst($this->rootNamespace(), '', $complementName);
+
+        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+    }
+
+	/**
+	 * Get the stub file for the generator.
+	 *
+	 * @return string
+	 */
+	protected function getStub()
+	{
+        if($this->option('interface'))
+        {
+            $this->type = $this->complementaryInterfaceName;
+		    return  __DIR__ . '/../stubs/make-service-interface.stub';
+        }
+
+        $this->type = $this->complementaryServiceName;
+        return  __DIR__ . '/../stubs/make-service.stub';
+	}
+
+	/**
+	 * Get the default namespace for the class.
+	 *
+	 * @param  string  $rootNamespace
+	 * @return string
+	 */
+	protected function getDefaultNamespace($rootNamespace)
+	{
+        if($this->option('interface'))
+        {
+           return $this->getServiceInterfaceNameSpace();
+        }
+
+        return $this->getServiceNameSpace();
+	}
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the contract.'],
+        ];
+    }
+
+    protected function getOptions()
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Create the class even if it already exists'],
+            ['interface', null, InputOption::VALUE_NONE, 'Create the interface class for repository']
+        ];
+    }
+
+    private function getRepositoryInterfaceNameSpace()
+    {
+        if (config('makeservicerepository.base.create_contract_in_same_folder_entity')) {
+            return config('makeservicerepository.base.repository_pattern_directory') .'\\'. $this->argument('name');
+        }
+
+        return config('makeservicerepository.base.repository_contract_pattern_directory');
+    }
+
+    private function getServiceInterfaceNameSpace()
+    {
+        if (config('makeservicerepository.base.create_contract_in_same_folder_entity')) {
+            return config('makeservicerepository.base.service_pattern_directory') .'\\'. $this->argument('name');
+        }
+
+        return config('makeservicerepository.base.service_contract_pattern_directory');
+    }
+
+    private function getServiceNameSpace()
+    {
+        if (config('makeservicerepository.base.create_contract_in_same_folder_entity')) {
+            return config('makeservicerepository.base.service_pattern_directory') .'\\'. $this->argument('name');
+        }
+
+		return config('makeservicerepository.base.service_pattern_directory');
+    }
+}

--- a/src/Console/Commands/MakeServiceRepositoryCrud.php
+++ b/src/Console/Commands/MakeServiceRepositoryCrud.php
@@ -35,11 +35,17 @@ class MakeServiceRepositoryCrud extends Command
         $name = (string) $this->argument('name');
         $nameTitle = ucfirst(Str::camel($name));
 
-        $this->call('make:repository', ['name' => $nameTitle, '--interface'=> true]);
-        $this->call('make:repository', ['name' => $nameTitle]);
+        if ($this->confirm('Create Repository Interface ? ', true)){
+            $this->call('make:repositoryPattern', ['name' => $nameTitle, '--interface'=> true]);
+        }
+
+        $this->call('make:repositoryPattern', ['name' => $nameTitle]);
 
         // Create a service interface and repository
-        $this->call('make:service', ['name' => $nameTitle, '--interface'=> true]);
-        $this->call('make:service', ['name' => $nameTitle]);
+        if ($this->confirm('Create Service Interface ? ', true)){
+            $this->call('make:servicePattern', ['name' => $nameTitle, '--interface'=> true]);
+        }
+
+        $this->call('make:servicePattern', ['name' => $nameTitle]);
     }
 }

--- a/src/Console/stubs/make-repository-interface.stub
+++ b/src/Console/stubs/make-repository-interface.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Contracts\Repositories;
+namespace DummyNamespace;
 
 interface DummyRepositoryContract
 {

--- a/src/Console/stubs/make-repository.stub
+++ b/src/Console/stubs/make-repository.stub
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Repositories;
+namespace DummyNamespace;
 
-use App\Contracts\Repositories\DummyRepositoryInterface;
+use DummyRepositoryInterfaceNamespace\DummyRepositoryInterface;
 use App\Models\DummyModel;
 
 class DummyRepository implements DummyRepositoryInterface

--- a/src/Console/stubs/make-service-interface.stub
+++ b/src/Console/stubs/make-service-interface.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Contracts\Services;
+namespace DummyNamespace;
 
 interface DummyContract
 {

--- a/src/Console/stubs/make-service.stub
+++ b/src/Console/stubs/make-service.stub
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\Services;
+namespace DummyNamespace;
 
-use App\Contracts\Services\DummyServiceInterface;
-use App\Contracts\Repositories\DummyRepositoryInterface;
+use DummyServiceInterfacePath\DummyServiceInterface;
+use DummyRepositoryInterfacePath\DummyRepositoryInterface;
 
 class DummyService implements DummyServiceInterface
 {

--- a/src/MakeServiceRepositoryServiceProvider.php
+++ b/src/MakeServiceRepositoryServiceProvider.php
@@ -5,13 +5,17 @@ namespace FelipeDamacenoTeodoro\MakeServiceRepository;
 use Illuminate\Support\ServiceProvider;
 use FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands\MakeRepository;
 use FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands\MakeRepositoryContract;
+use FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands\MakeRepositoryPattern;
 use FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands\MakeService;
 use FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands\MakeServiceContract;
+use FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands\MakeServicePattern;
 use FelipeDamacenoTeodoro\MakeServiceRepository\Console\Commands\MakeServiceRepositoryCrud;
 
 class MakeServiceRepositoryServiceProvider extends ServiceProvider
 {
     protected $commands = [
+        MakeServicePattern::class,
+        MakeRepositoryPattern::class,
         MakeService::class,
         MakeRepository::class,
         MakeServiceRepositoryCrud::class,


### PR DESCRIPTION
- Modify params of files make repository and make service
- For create only interface class use : make:repository --interface, make:repository, make:service --interface and make:service
- For set your folder of services and repositories publish the config file: php artisan vendor:publish --tag=makeservicerepository-config
- Allows configuring whether the contracts will be in the same entity's folder through the config file in the parameter create_contract_in_same_folder_entity by default it is true